### PR TITLE
Remove unnecessary code from bst.py

### DIFF
--- a/bst.py
+++ b/bst.py
@@ -275,12 +275,10 @@ class Node(object):
         if self.left is not None:
             self.left.parent = self
         pivot.left = pivot.right
-        if pivot.left is not None:
-            pivot.left.parent = pivot
         pivot.right = self.right
         if pivot.right is not None:
             pivot.right.parent = pivot
-        self.right, pivot.parent = pivot, self
+        self.right = pivot
 
     def _rotate_left(self):
         """Perform a single left tree rotation."""
@@ -292,12 +290,10 @@ class Node(object):
         if self.right is not None:
             self.right.parent = self
         pivot.right = pivot.left
-        if pivot.right is not None:
-            pivot.right.parent = pivot
         pivot.left = self.left
         if pivot.left is not None:
             pivot.left.parent = pivot
-        self.left, pivot.parent = pivot, self
+        self.left = pivot
 
     def _self_balance(self):
         """Balance the subtree from given node."""


### PR DESCRIPTION
The methods _rotate_right and _rotate_left in bst.py have a few unnecessary lines of code which can be removed without altering the functionality of the methods. Both _rotate_right and _rotate_left contain an if block that changes the "parent" instance variable of the pivot node to equal the pivot's current parent. This is not needed because the "parent" member variable of the pivot node does not change when altering the pivot's left and right subtrees. Because of this, the following lines of code can safely be removed without changing the functionality of _rotate_right and _rotate_left: 278, 279, 295, 296.

Also, the last line of both _rotate_right and _rotate_left update the "parent" instance variable of the pivot to equal the pivot's current parent. The manner in which the tree is rotated does not change the "parent" instance variable of the pivot node; therefore, the last line of each of these methods (lines 283 and 300) can be updated so that they do not change the "parent" instance variable of the pivot node considering that the pivot's parent is constant throughout these two methods.
