### PR TITLE
Remove unnecessary code from bst.py

### DIFF
--- a/bst.py
+++ b/bst.py
@@ -275,12 +275,10 @@ class Node(object):
         if self.left is not None:
             self.left.parent = self
         pivot.left = pivot.right
-        if pivot.left is not None:
-            pivot.left.parent = pivot
         pivot.right = self.right
         if pivot.right is not None:
             pivot.right.parent = pivot
-        self.right, pivot.parent = pivot, self
+        self.right = pivot
 
     def _rotate_left(self):
         """Perform a single left tree rotation."""
@@ -292,12 +290,10 @@ class Node(object):
         if self.right is not None:
             self.right.parent = self
         pivot.right = pivot.left
-        if pivot.right is not None:
-            pivot.right.parent = pivot
         pivot.left = self.left
         if pivot.left is not None:
             pivot.left.parent = pivot
-        self.left, pivot.parent = pivot, self
+        self.left = pivot
 
     def _self_balance(self):
         """Balance the subtree from given node."""


### PR DESCRIPTION
Simplify the bst left and right rotation methods

Remove the if block in the _rotate_right and _rotate_left methods from 
bst.py that validate the parent node of the pivot, as well as the code
that updates the pivot's parent at the end of _rotate_right and 
_rotate_left.

The pivot's parent does not change throughout the rotation of the tree.
Get rid of the lines that update the parent of the pivot node because 
the parent of the pivot stays constant in _rotate_left and 
_rotate_right. Lines 278, 279, 295, 296 can be deleted without altering
the functionality of the rotation algorithms and gets rid of the 
unneeded code that updates the parent of the pivot node.

In addition, lines 283 and 300 also unnecessarily update the parent of
the pivot node. This can be removed without changing the functionality
of _rotate_left and _rotate_right.

The parent of the pivot node does not change in _rotate_right or
_rotate_left. Delete code that updates the parent of pivot.